### PR TITLE
Add --no-save flag to sdf dbt refresh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -97,9 +97,9 @@ fi
 if [[ -n $input_is_dbt ]]; then
   echo "::group::Setting up dbt"
   if [[ -z $dbt_profiles_dir ]]; then
-    sdf dbt refresh
+    sdf dbt refresh --no-save
   else
-    sdf dbt refresh --profiles-dir $dbt_profiles_dir
+    sdf dbt refresh --profiles-dir $dbt_profiles_dir --no-save
   fi
   check_exit_status $? ""
   echo "::endgroup::"


### PR DESCRIPTION
This currently breaks workflows that define functions as it overwrites the workspace file!